### PR TITLE
Toy MC Systematics

### DIFF
--- a/bin/BuildFile.xml
+++ b/bin/BuildFile.xml
@@ -25,6 +25,7 @@
   <bin name="mc_reco_signal_study"   file="mc_reco_signal_study.cc"></bin> 
   <bin name="reweight"   file="reweighting.cc"></bin>
   <bin name="res"   file="resolution.cc"></bin>
+  <bin name="Res"   file="Resolution.cc"></bin>
   <bin name="effratioplot"   file="eff_ratio_plot.cc"></bin>
 </environment>
 

--- a/bin/calculate_bin_syst.cc
+++ b/bin/calculate_bin_syst.cc
@@ -457,6 +457,7 @@ double reweighting_syst(int channel, double pt_min, double pt_max, double y_min,
   std::vector<TString> reweight_var_names;
   reweight_var_names.push_back("mu1pt");
   reweight_var_names.push_back("pt");
+  reweight_var_names.push_back("lerrxy");
 
   RooRealVar* eff_corrected;
   int reweight_variables_number = static_cast<int>(reweight_var_names.size());  

--- a/bin/fitBias.cc
+++ b/bin/fitBias.cc
@@ -1,120 +1,96 @@
 #include "UserCode/B_production_x_sec_13_TeV/interface/functions.h"
 #include "TH2.h"
 
-using namespace RooFit ;
+using namespace RooFit;
 
-int main()
+//Running example: fitBias --channel 4 --ptmin 9 --ptmax 13
+int main(int argc, char** argv)
 {
+  int channel = 1;
+  double pt_min = 9., pt_max = 13.;
+  for(int i=1 ; i<argc ; ++i)
+    {
+      std::string argument = argv[i];
+      std::stringstream convert;
+      if(argument == "--channel")
+        {
+          convert << argv[++i];
+          convert >> channel;
+        }
+      if(argument == "--ptmin")
+        {
+          convert << argv[++i];
+          convert >> pt_min;
+        }
+      if(argument == "--ptmax")
+        {
+          convert << argv[++i];
+          convert >> pt_max;
+        }
+    }
 
-  /////////////////////////////////////////////////////////////////
-  ///////Produce RooWorkspace /////////////////////////////////////
-  /////////////////////////////////////////////////////////////////
-  RooWorkspace *w = new RooWorkspace("w", "RooWorkspace Title");
-  int channel = 4;
-  set_up_workspace_variables(*w, channel);
-  TString data_selection_input_file = TString::Format(BASE_DIR) + "/new_inputs/myloop_new_data_" + channel_to_ntuple_name(channel) + "_with_cuts.root";
-  read_data(*w, data_selection_input_file, channel);
-  
-  RooRealVar mass = *(w->var("mass"));
-  RooRealVar pt = *(w->var("pt"));
-  RooRealVar y = *(w->var("y"));
-  RooRealVar pt_low("pt_low", "pt_low", 9.);
-  RooRealVar pt_high("pt_high", "pt_high", 90.);
-  RooRealVar y_low("y_low", "y_low", -2.25);
-  RooRealVar y_high("y_high", "y_high", 2.25);
-  RooDataSet *data =(RooDataSet*) w->data("data");
-  RooFormulaVar cut("cut", "pt>pt_low && pt<pt_high && y>y_low && y<y_high", RooArgList(pt, pt_low, pt_high, y, y_low, y_high));
-  data->reduce(cut);
-  
-  //signal component
-  RooRealVar mean("mean","mean", BS_MASS, BS_MASS-0.09, BS_MASS+0.09);
-  RooRealVar sigma1("sigma1","sigma1",0.010,0.009,0.200);
-  RooRealVar sigma2("sigma2","sigma2",0.005,0.004,0.100);
-  RooRealVar fraction("fraction","fraction", 0.4, 0., .85);
-  RooGaussian gaussian1("gaussian1","gaussian1",mass,mean,sigma1);
-  RooGaussian gaussian2("gaussian2","gaussian2",mass,mean,sigma2);
-  RooRealVar sig_frac("sig_frac","sig_frac", 0.20, 0., 0.9);
-  RooAddPdf sig("sig","sig",RooArgList(gaussian1,gaussian2), RooArgList(sig_frac));
+  std::vector<TString> params_names;
+  params_names.push_back("m_sigma1");
+  params_names.push_back("m_sigma2");
+  params_names.push_back("m_fraction");
+  params_names.push_back("m_exp");
+  if(channel == 1) {
+    params_names.push_back("m_nonprompt_scale");
+    params_names.push_back("m_nonprompt_shift");
+    params_names.push_back("m_jpsipi_fraction2");
+    params_names.push_back("m_jpsipi_fraction3");
+  }
+  else if(channel == 2) {
+    params_names.push_back("sigma_swapped1");
+    params_names.push_back("sigma_swapped2");
+    params_names.push_back("sigma_swapped3");
+    params_names.push_back("alpha1");
+    params_names.push_back("alpha2");
+    params_names.push_back("alpha3");
+    params_names.push_back("n1_parameter");
+    params_names.push_back("n2_parameter");
+    params_names.push_back("n3_parameter");
+    params_names.push_back("r1");
+    params_names.push_back("r2");
+  }
+  else if(channel == 4) {
+  }
+  else std::cout << "We are not currently calculating Pulls for this channel." << std::endl;
 
-  //background component
-  RooRealVar exponent("exponent","exponent",-1.,-4.,0.);
-  RooExponential bkg("bkg","bkg",mass,exponent);
+  int params_size = params_names.size();
 
-  //full pdf model
-  RooRealVar nbkg("nbkg","nbkg",6000,0,50000) ;
-  RooRealVar nsig("nsig","nsig",6000,0,50000) ;
-  RooAddPdf  model("model","model",RooArgList(bkg,sig),RooArgList(nbkg,nsig));
+  //here I will use the ptmin and ptmax according to the bin I am reading
+  TFile file_open("XXXXXXX.root", "OPEN");
 
-  //fit and plot
-  RooPlot* frame = mass.frame(Title("Test Fit"));
-  data->plotOn(frame);
-  model.fitTo(*data);
-  model.paramOn(frame, Layout(0.6,0.96,0.8));
-  model.plotOn(frame, LineColor(7), LineWidth(4), LineStyle(1));
-  model.plotOn(frame,Components("gaussian1"),LineColor(8),LineWidth(4),LineStyle(2));
-  model.plotOn(frame,Components("gaussian2"),LineColor(5),LineWidth(4),LineStyle(2));
-  model.plotOn(frame,Components("bkg"),LineColor(6),LineWidth(4),LineStyle(2));
-
-  TCanvas c; c.cd();
-  frame->Draw();
-  c.SaveAs("nominal_fit.png");
-
-  TFile file("RooWorkspaceStorage.root", "RECREATE");
-  w->import(model);
-  w->Write();
-  file.Close();
-  
-  // Instantiate RooMCStudy manager on model with mass as observable and given choice of fit options
-  //
-  // The Silence() option kills all messages below the PROGRESS level, leaving only a single message
-  // per sample executed, and any error message that occur during fitting
-  //
-  // The Extended() option has two effects: 
-  //    1) The extended ML term is included in the likelihood and 
-  //    2) A poisson fluctuation is introduced on the number of generated events 
-  //
-  // The FitOptions() given here are passed to the fitting stage of each toy experiment.
-  // If Save() is specified, the fit result of each experiment is saved by the manager  
-  //
-  // A Binned() option is added in this example to bin the data between generation and fitting
-  // to speed up the study at the expemse of some precision
-
-
-  TFile file_open("RooWorkspaceStorage.root", "OPEN");
   RooWorkspace *w_open = static_cast<RooWorkspace*>(file_open.Get("w"));
   RooRealVar mass_open = *(w_open->var("mass"));
-  RooRealVar mean_open = *(w_open->var("mean"));
-  RooRealVar sigma1_open = *(w_open->var("sigma1"));
+  std::vector<RooRealVar> params;
+  for(int i=0; i<params_size; ++i) {
+    params.push_back(*(w_open->var(params_names.at(i))));
+  }
   RooAbsPdf *model_open = w_open->pdf("model");
   
-  RooMCStudy* mcstudy = new RooMCStudy(*model_open,mass_open,/*FitModel()*/Binned(kTRUE),Silence(),Extended(),FitOptions(Save(kTRUE),PrintEvalErrors(0)));
-  std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
-  std::cout << sigma1_open.getVal() << std::endl;
-  std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
+  RooMCStudy* mcstudy = new RooMCStudy(*model_open,mass_open,Binned(kTRUE),Silence(),Extended(),FitOptions(Save(kTRUE),PrintEvalErrors(0)));
+
   // Generate and fit 1000 samples of Poisson(nExpected) events
   mcstudy->generateAndFit(1000);
 
-  // Make plots of the distributions of mean, the error on mean and the pull of mean
-  RooPlot* frame1 = mcstudy->plotParam(mean_open,Bins(40));
-  RooPlot* frame2 = mcstudy->plotPull(sigma1_open,Bins(40),FitGauss(kTRUE));
-  RooPlot* frame3 = mcstudy->plotPull(mean_open,Bins(40),FitGauss(kTRUE));
-
-  // Plot distribution of minimized likelihood
-  RooPlot* frame4 = mcstudy->plotNLL(Bins(40));
-
- std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
-  std::cout << sigma1_open.getVal() << std::endl;
-  std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl;
+  // Make plots of the distributions of the pull of each parameter
+  std::vector<RooPlot*> frames;
+  for (int i=0; i<params_size; ++i) {
+    frames.push_back(mcstudy->plotPull(params.at(i),Bins(40),FitGauss(kTRUE)));
+  }
 
   // Draw all plots on a canvas
   gStyle->SetPalette(1);
   gStyle->SetOptStat(0);
-  TCanvas* c2 = new TCanvas("toyMC_test","toyMC_test",900,900);
-  c2->Divide(2,2);
-  c2->cd(1) ; gPad->SetLeftMargin(0.15) ; frame1->GetYaxis()->SetTitleOffset(1.4) ; frame1->Draw() ;
-  c2->cd(2) ; gPad->SetLeftMargin(0.15) ; frame2->GetYaxis()->SetTitleOffset(1.4) ; frame2->Draw() ;
-  c2->cd(3) ; gPad->SetLeftMargin(0.15) ; frame3->GetYaxis()->SetTitleOffset(1.4) ; frame3->Draw() ;
-  c2->cd(4) ; gPad->SetLeftMargin(0.15) ; frame4->GetYaxis()->SetTitleOffset(1.4) ; frame4->Draw() ;
-
-  c2->SaveAs("fitBias.png");  
+  std::vector<TCanvas*> canvases;
+  for(int i=0; i<params_size; ++i) {
+    canvases.push_back(new TCanvas("canvas_"+params_names.at(i), "canvas_"+params_names.at(i), 900, 900));
+    canvases.at(i)->cd();
+    gPad->SetLeftMargin(0.15);
+    frames.at(i)->GetYaxis()->SetTitleOffset(1.4);
+    frames.at(i)->Draw();
+    canvases.at(i)->SaveAs("pull_"+params_names.at(i)+".png");
+  }
 }

--- a/bin/mc_validation.cc
+++ b/bin/mc_validation.cc
@@ -50,7 +50,7 @@
 using namespace RooFit;
 
 #define VAR_NUMBER 17 //the variable 'mass' has to be the last one to be stored
-#define BIN_NUMBER 75 
+#define BIN_NUMBER 100 
 
 //void newNtuple(std::string filename_open, std::string filename_save, int channel);
 void read_data(RooWorkspace& w, std::string filename, int channel);

--- a/interface/functions.h
+++ b/interface/functions.h
@@ -9,6 +9,7 @@
 #include <TStyle.h>
 #include <TAxis.h>
 #include <TLatex.h>
+#include <TCut.h>
 #include <TPaveText.h>
 #include <TFile.h>
 #include <TTree.h>
@@ -24,6 +25,7 @@
 #include <RooProduct.h>
 #include <RooConstVar.h>
 #include <RooDataSet.h>
+#include <RooDataHist.h>
 #include <RooGaussian.h>
 #include <RooBifurGauss.h>
 #include <RooChebychev.h>
@@ -942,6 +944,7 @@ RooRealVar* reco_efficiency(int channel, double pt_min, double pt_max, double y_
   //set up the variables needed
   double pt_b, eta_b, y_b, pt_mu1, pt_mu2, eta_mu1, eta_mu2;
   double reweighting_variable;
+  double lxy, errxy;
   
   //read the ntuple from selected_data
   tin_no_cuts->SetBranchAddress("eta", &eta_b);
@@ -951,10 +954,13 @@ RooRealVar* reco_efficiency(int channel, double pt_min, double pt_max, double y_
   tin_no_cuts->SetBranchAddress("mu2pt", &pt_mu2);
   tin_no_cuts->SetBranchAddress("mu1eta", &eta_mu1);
   tin_no_cuts->SetBranchAddress("mu2eta", &eta_mu2);
- 
+  if(reweighting_var_str == "lerrxy") {
+    tin_no_cuts->SetBranchAddress("lxy", &lxy);
+    tin_no_cuts->SetBranchAddress("errxy", &errxy);
+  }
+
   if(syst) {
-    if (reweighting_var_str != "eta" && reweighting_var_str != "y" && reweighting_var_str != "pt" && reweighting_var_str != "mu1pt" 
-	&& reweighting_var_str != "mu2pt" && reweighting_var_str != "mu1eta" && reweighting_var_str != "mu2eta")
+    if (reweighting_var_str != "eta" && reweighting_var_str != "y" && reweighting_var_str != "pt" && reweighting_var_str != "mu1pt" && reweighting_var_str != "mu2pt" && reweighting_var_str != "mu1eta" && reweighting_var_str != "mu2eta" && reweighting_var_str != "lerrxy")
       tin_no_cuts->SetBranchAddress(reweighting_var_str, &reweighting_variable);
   }
 
@@ -1000,6 +1006,7 @@ RooRealVar* reco_efficiency(int channel, double pt_min, double pt_max, double y_
 	  }
 	  else if (reweighting_var_str == "mu1eta") weight_tot += h_weights_tot->GetBinContent( h_weights_tot->FindBin(eta_mu1) );
 	  else if (reweighting_var_str == "mu2eta") weight_tot += h_weights_tot->GetBinContent( h_weights_tot->FindBin(eta_mu2) );
+	  else if (reweighting_var_str == "lerrxy") weight_tot += h_weights_tot->GetBinContent( h_weights_tot->FindBin(lxy/errxy) );
 	}
       }
 
@@ -1021,10 +1028,13 @@ RooRealVar* reco_efficiency(int channel, double pt_min, double pt_max, double y_
     tin_with_cuts->SetBranchAddress("mu2pt", &pt_mu2);
     tin_with_cuts->SetBranchAddress("mu1eta", &eta_mu1);
     tin_with_cuts->SetBranchAddress("mu2eta", &eta_mu2);
+    if(reweighting_var_str == "lerrxy") {
+      tin_no_cuts->SetBranchAddress("lxy", &lxy);
+      tin_no_cuts->SetBranchAddress("errxy", &errxy);
+    }
  
     if(syst) {
-      if (reweighting_var_str != "eta" && reweighting_var_str != "y" && reweighting_var_str != "pt" && reweighting_var_str != "mu1pt" 
-	&& reweighting_var_str != "mu2pt" && reweighting_var_str != "mu1eta" && reweighting_var_str != "mu2eta")
+      if (reweighting_var_str != "eta" && reweighting_var_str != "y" && reweighting_var_str != "pt" && reweighting_var_str != "mu1pt" && reweighting_var_str != "mu2pt" && reweighting_var_str != "mu1eta" && reweighting_var_str != "mu2eta" && reweighting_var_str != "lerrxy")
 	tin_with_cuts->SetBranchAddress(reweighting_var_str, &reweighting_variable);
     }
     TH1D* hist_passed = new TH1D("hist_passed","hist_passed",1,pt_min,pt_max);
@@ -1066,6 +1076,7 @@ RooRealVar* reco_efficiency(int channel, double pt_min, double pt_max, double y_
 	    }
 	    else if (reweighting_var_str == "mu1eta") weight_passed += h_weights_passed->GetBinContent( h_weights_passed->FindBin(eta_mu1) );
 	    else if (reweighting_var_str == "mu2eta") weight_passed += h_weights_passed->GetBinContent( h_weights_passed->FindBin(eta_mu2) );
+	    else if (reweighting_var_str == "lerrxy") weight_passed += h_weights_passed->GetBinContent( h_weights_passed->FindBin(lxy/errxy) );
 	  }
 	}
 

--- a/interface/functions.h
+++ b/interface/functions.h
@@ -325,7 +325,7 @@ void build_pdf(RooWorkspace& w, int channel, std::string choice, std::string cho
   RooCBShape swapped3("swapped3","swapped3", mass, m_mean, sigma_swapped3, alpha3, n3_parameter);
 
   RooRealVar r1("r1","r1", 0.249); 
-  RooRealVar r2("r12","r12", 0.3922);
+  RooRealVar r2("r2","r2", 0.3922);
   RooAddPdf k_pi_swap("k_pi_swap","k_pi_swap", RooArgSet(swapped1,swapped2,swapped3), RooArgSet(r1,r2));
 
   //--------------------------------------------------------------------


### PR DESCRIPTION
1. Acrescentei uma macro independente que será usada para calcular o erro sistemático devido às possíveis variações dos parâmetros de fit tendo em conta vários distribuições geradas a partir da função nominal (toy MCs). Terminá-la-ei assim que me disseres como pretendes dar a informação acerca dos vários parâmetros. Neste momento assumi que irás gravar tudo num RooWorkspace, diferente para cada bin, e que é de lá que retiro todos os parâmetros que necessito, bem como a variável dependente (a massa) e a função de fit usada.

2. Agora o sistemático da eficiência também considera o 'lerrxy'. Neste momento não está a funcionar porque os ficheiros reduced_... não incluem as variáveis 'lxy' e 'errxy'. Podes incluí-las?