### PR TITLE
Yield stability

### DIFF
--- a/bin/RunNoFilter.cc
+++ b/bin/RunNoFilter.cc
@@ -1,0 +1,202 @@
+#include "UserCode/B_production_x_sec_13_TeV/interface/functions.h"
+#include "UserCode/B_production_x_sec_13_TeV/interface/BWarnings.h"
+#include <iostream>
+#include <fstream>
+
+int main(int argc, char** argv)
+{
+  int channel = 1;
+  bool json = false;
+  BWarnings Warn;
+  TString sample_kind, particle;
+
+  for(int i=1 ; i<argc ; ++i)
+    {
+      std::string argument = argv[i];
+      std::stringstream convert;
+      if(argument == "--channel")
+        {
+          convert << argv[++i];
+          convert >> channel;
+        }
+      if(argument == "--json")
+        {
+          convert << argv[++i];
+          convert >> json;
+        }
+    }
+
+  //int RunLimits[6] = {0, 257000, 258100, 259000, 260000, 270000};
+  int RunLimits[6] = {0, 257500, 258250, 259000, 260400, 270000};
+
+  /*  TFile* file = new TFile("/lstore/cms/brunogal/input_for_B_production_x_sec_13_TeV/new_inputs/myloop_new_data_" + channel_to_ntuple_name(channel) + "_with_cuts.root","OPEN");
+  Warn.CheckPointer(file);
+  TTree* tree = static_cast<TTree*>(file->Get(channel_to_ntuple_name(channel)));
+  Warn.CheckPointer(tree);
+  TFile* f1 = new TFile("/lstore/cms/balves/Jobs/Full_Dataset_2015_Rereco/D/D1/"+channel_to_ntuple_name(channel)+"_2.root", "RECREATE");
+  TTree* t1 = tree->CloneTree(0);
+  TFile* f2 = new TFile("/lstore/cms/balves/Jobs/Full_Dataset_2015_Rereco/D/D2/"+channel_to_ntuple_name(channel)+"_2.root", "RECREATE");
+  TTree* t2 = tree->CloneTree(0);
+  TFile* f3 = new TFile("/lstore/cms/balves/Jobs/Full_Dataset_2015_Rereco/D/D3/"+channel_to_ntuple_name(channel)+"_2.root", "RECREATE");
+  TTree* t3 = tree->CloneTree(0);
+  TFile* f4 = new TFile("/lstore/cms/balves/Jobs/Full_Dataset_2015_Rereco/D/D4/"+channel_to_ntuple_name(channel)+"_2.root", "RECREATE");
+  TTree* t4 = tree->CloneTree(0);  
+  TFile* f5 = new TFile("/lstore/cms/balves/Jobs/Full_Dataset_2015_Rereco/D/D5/"+channel_to_ntuple_name(channel)+"_2.root", "RECREATE");
+  TTree* t5 = tree->CloneTree(0);
+
+  int run;
+  tree->SetBranchAddress("run",&run);
+
+  int nentries = tree->GetEntries();
+  for(int entry=0; entry<nentries; ++entry) {
+    tree->GetEntry(entry);
+    if (run > RunLimits[0] && run < RunLimits[1]) { 
+      f1->cd();
+      t1->Fill();
+    }
+    else if (run >= RunLimits[1] && run < RunLimits[2]) {
+      f2->cd();
+      t2->Fill();
+    }
+    else if (run >= RunLimits[2] && run < RunLimits[3]) {
+      f3->cd();
+      t3->Fill();
+    }
+    else if (run >= RunLimits[3] && run < RunLimits[4]) {
+      f4->cd();
+      t4->Fill();
+    }
+    else if (run >= RunLimits[4]) {
+      f5->cd();
+      t5->Fill();
+    }
+    else std::cout << run << ": this run is not covered in the defined range!" << std::endl;
+  }
+
+  f1->Write();
+  f2->Write();
+  f3->Write();
+  f4->Write();
+  f5->Write();
+
+  delete file;
+  delete f1;
+  delete f2;
+  delete f3;
+  delete f4;  
+  delete f5;
+  */  
+  //////////////////////////////////////
+  //////////JSON MANIPULATOR////////////
+  //////////////////////////////////////
+  if(json) 
+    {
+      int jsonOutSize = 5;
+      std::vector<std::ifstream> jsonIn(7);
+      std::vector<std::ofstream> jsonOut(jsonOutSize);
+      std::string pathIn = "/home/t3cms/balves/work/CMSSW_8_0_22/src/UserCode/Bfinder/lumis2015rereco/";
+      std::string pathOut = "/lstore/cms/balves/Jobs/Full_Dataset_2015_Rereco/D/";
+
+      for (int i=0; i<7; ++i) {
+	jsonIn.at(i).open(pathIn + "D" + std::to_string(i+1) + ".json");
+	if(!jsonIn[i]) std::cout << "Input file did not open!" << std::endl;
+      }
+      for (int i=0; i<jsonOutSize; ++i) {
+	jsonOut.at(i).open(pathOut + "D" + std::to_string(i+1) + "/D" + std::to_string(i+1) + "_2.json", std::ios_base::trunc);
+	if(!jsonOut[i]) std::cout << "Output file did not open!" << std::endl;
+      }
+
+      for (int i=0; i<jsonOutSize; ++i) {
+	jsonOut[i] << "{";
+      }
+
+      std::string Save0="", Save1="", Save2="", Save2_aux1="", Save2_aux2="";
+      int JsonRunNo = -1;
+      bool end_of_file = false;
+      std::vector<bool> was_file_already_opened(jsonOutSize); //initialize all elements to false
+      char delimiter = '"';
+
+      for (int i=0; i<7; ++i) {
+	end_of_file = false;
+	Save0 = "";
+	Save1 = "";
+	Save2 = "";
+	Save2_aux1 = "";
+	Save2_aux2 = "";
+	while(!jsonIn[i].eof()) 
+	  {
+	    //goes until the first '"' and stores what lies before the first '"'
+	    std::getline(jsonIn[i], Save0, delimiter);
+	    //goes until the second '"' and stores what in between the two '"'
+	    if (Save0.find("}") != std::string::npos) {
+	      break;
+	    }
+	    else {
+	      if(Save0 == ", ") Save0 = "";
+	      std::getline(jsonIn[i], Save1, delimiter); 
+	      JsonRunNo = std::stoi(Save1);
+	    }
+	    //std::cout << "Number: " << JsonRunNo << std::endl;
+	    bool run_check = false;
+	    for (int j=0; j<5; ++j) {
+              if (JsonRunNo > RunLimits[j] && JsonRunNo < RunLimits[j+1]) {
+		run_check = true;
+	      }
+	    }
+	    if(run_check==false) std::cout << "The run number " << JsonRunNo << "is out of the range!" << std::endl;
+	    for (int j=0; j<5; ++j) {
+	      if (JsonRunNo > RunLimits[j] && JsonRunNo < RunLimits[j+1] && !end_of_file) { 
+		if(Save0 != "{") {
+		  jsonOut[j] << Save0; //to avoid more than one '{' to appear
+		}
+		else {
+		  if(was_file_already_opened[j] == true) jsonOut[j] << ""; //are we at the beginning of the file?
+		}
+		was_file_already_opened[j] = true; 
+		jsonOut[j] << "\"";
+		jsonOut[j] << Save1;
+		jsonOut[j] << "\"";
+		std::getline(jsonIn[i], Save2, ']');
+		Save2 += "]";
+		Save2_aux2 = "]";
+		bool new_while = false;
+		while(!jsonIn[i].eof() ) {
+		  Save2_aux1 = jsonIn[i].get();
+		  //check in case the first ']' is found by Save2_aux2
+		  if(new_while == true && Save2_aux1 == "]" && Save2_aux2 == "]") {
+		    Save2 += "]";
+		    break;
+		  }
+		  //'new_while' checks for first loop
+		  if(new_while == false && Save2_aux1 == "]") { 
+		    Save2 += "]";
+		    break;
+		  }
+		  else {
+		    new_while = true;
+		    Save2_aux2 = jsonIn[i].get();
+		    Save2 += Save2_aux1 + Save2_aux2;
+		    if(Save2_aux1 == "]" && Save2_aux2 == "]") break;
+		  }
+		}
+		jsonOut[j] << Save2  + ", ";
+	      }
+	    }
+	  }
+      }
+
+
+      for (int i=0; i<7; ++i) {
+	jsonIn[i].close();
+      }
+      for (int i=0; i<jsonOutSize; ++i) {
+	jsonOut[i] << "}";
+	jsonOut[i].close();
+      }
+    }
+  /////////////////////////////////////
+  /////////////////////////////////////
+  /////////////////////////////////////
+
+  return 0;
+}

--- a/bin/TagProbe_with_ScaleFactors.cc
+++ b/bin/TagProbe_with_ScaleFactors.cc
@@ -1,0 +1,179 @@
+#include "UserCode/B_production_x_sec_13_TeV/interface/functions.h"
+#include <boost/numeric/ublas/matrix.hpp>
+#include <boost/numeric/ublas/io.hpp>
+#include <iostream>
+#include <fstream>
+
+using namespace RooFit;
+double getWeight(TFile *f, double muon_y, double muon_pt);
+std::pair<int,int> currentBin(int nbins_y, int nbins_pt, double b_y, double b_pt, int channel);
+std::pair<int,int> getBinpT(int channel, int bin_number);
+std::pair<float,float> getBiny(int channel, int bin_number);
+void printSystematics(int channel, TString name, std::vector<double>& systematics);
+
+int main(int argc, char** argv)
+{
+  int channel = 1;
+  for(int i=1 ; i<argc ; ++i)
+    {
+      std::string argument = argv[i];
+      std::stringstream convert;
+      if(argument == "--channel")
+        {
+          convert << argv[++i];
+          convert >> channel;
+        }
+    }
+
+  //open table to store all values
+  std::ofstream Table;
+  Table.open("./Table_SoftMuonID_Syst_" + channel_to_ntuple_name(channel) + ".csv");
+
+  int nbins_pt = 0, nbins_y = 0;
+  switch(channel)
+    {
+    case 1: nbins_pt = sizeof(ntkp_pt_bins)/sizeof(*ntkp_pt_bins)-1;        nbins_y = sizeof(ntkp_y_bins)/sizeof(*ntkp_y_bins)-1;        break;
+    case 2: nbins_pt = sizeof(ntkstar_pt_bins)/sizeof(*ntkstar_pt_bins)-1;  nbins_y = sizeof(ntkstar_y_bins)/sizeof(*ntkstar_y_bins)-1;  break;
+    case 4: nbins_pt = sizeof(ntphi_pt_bins)/sizeof(*ntphi_pt_bins)-1;      nbins_y = sizeof(ntphi_y_bins)/sizeof(*ntphi_y_bins)-1;      break;
+    default: std::cout << "The chosen channel is not supported." << std::endl;
+    }
+  boost::numeric::ublas::matrix<double> weight_product(nbins_y, nbins_pt);
+  boost::numeric::ublas::matrix<int> subsample_entries(nbins_y, nbins_pt);
+  //boost::numeric::ublas::matrix<double> systematics(nbins_y, nbins_pt);
+  std::vector<double> systematics(nbins_pt);
+
+  //Open the MC analysis file and the file with the Tag and Probe weights
+  TString dir = "/lstore/cms/brunogal/input_for_B_production_x_sec_13_TeV/new_inputs/";
+  TFile *f = new TFile(dir + "myloop_new_mc_truth_" + channel_to_ntuple_name(channel) + "_with_cuts.root", "OPEN");
+  TTree *t = static_cast<TTree*>(f->Get(channel_to_ntuple_name(channel)));
+  TString dir_w = "TnP/recipe_740/CMSSW_7_4_0/src/MuonAnalysis/TagAndProbe/test/jpsi/fitTreeAnalyzer/ratio_files/25ns/";
+  TFile *f_w = new TFile(dir_w + "MuonID_Soft2012_25ns__pt_abseta_separated__MC_vs_DATA.root", "OPEN");
+
+  //Access the needed variables
+  double b_pt, b_y, muon1_pt, muon1_y, muon2_pt, muon2_y;
+  t->SetBranchAddress("pt",&b_pt);
+  t->SetBranchAddress("y",&b_y);
+  t->SetBranchAddress("mu1pt",&muon1_pt);
+  t->SetBranchAddress("mu1eta",&muon1_y);
+  t->SetBranchAddress("mu2pt",&muon2_pt);
+  t->SetBranchAddress("mu2eta",&muon2_y);
+
+  //Loop trough the events of the MC analysis file to calculate both the number of events in each (pT,y) subsample and to calculate the muon efficiency for each muon pair coming from a certain B meson. Since the systematical error is going to be an average calculate with these two values, the values are incremented and are not separately stored per event
+  int mu1_count = 0, mu2_count = 0;
+  std::pair<int,int> currBin = std::make_pair(0,0);
+  for(int entry=0; entry<t->GetEntries(); ++entry)
+    {
+      if(muon1_pt>40.) mu1_count += 1;
+      if(muon2_pt>40.) mu2_count += 1;
+      t->GetEntry(entry);
+      currBin = currentBin(subsample_entries.size1(),subsample_entries.size2(),b_y,b_pt,channel);
+      subsample_entries(currBin.first,currBin.second) += 1;
+      weight_product(currBin.first,currBin.second) += getWeight(f_w,muon1_y,muon1_pt)*getWeight(f_w,muon2_y,muon2_pt); 
+    }
+
+  std::cout << static_cast<double>(mu1_count)/static_cast<double>(t->GetEntries()) << std::endl;
+  std::cout << static_cast<double>(mu2_count)/static_cast<double>(t->GetEntries()) << std::endl;
+
+  //calculate the systematical uncertainty per bin of pT and rapidity
+  int subsample_entries_sum = 0;
+  double  weight_product_sum = 0;
+  for(unsigned int i=0; i<weight_product.size2(); ++i) { //cycle over pT
+    subsample_entries_sum = 0; 
+    weight_product_sum = 0.;
+    for (unsigned int j=0; j<weight_product.size1(); ++j) { //cycle over y
+      subsample_entries_sum += subsample_entries(j,i);
+      weight_product_sum += weight_product(j,i);
+    }
+    systematics.at(i) = (weight_product_sum/static_cast<double>(subsample_entries_sum) - 1);
+  }
+  printSystematics(channel,"./Table_SoftMuonID_Syst_" + channel_to_ntuple_name(channel) + ".csv",systematics);
+  return 0;
+}
+
+//return the edges of a pT bin
+std::pair<int,int> getBinpT(int channel, int bin_number) 
+{
+  double *bins_vector_pt = nullptr;
+  switch(channel) {
+  case 1: bins_vector_pt = &ntkp_pt_bins[0];     break;
+  case 2: bins_vector_pt = &ntkstar_pt_bins[0];  break;
+  case 4: bins_vector_pt = &ntphi_pt_bins[0];    break;
+  default: std::cout << "The chosen channel is not supported." << std::endl;
+  }
+  std::pair<int,int> pair = std::make_pair(bins_vector_pt[bin_number],bins_vector_pt[bin_number+1]);
+  return pair;
+}
+
+void printSystematics(int channel, TString name, std::vector<double>& systematics) 
+{
+  std::ofstream Table;
+  Table.open(name);
+
+  Table << " ,"; //top left corner of the table
+  for (unsigned int i_pt=0; i_pt<systematics.size(); ++i_pt) {
+    Table << getBinpT(channel,i_pt).first << " - " << getBinpT(channel,i_pt).second << ",";
+  }
+  Table << std::endl;
+  for(unsigned int i=0; i<systematics.size(); ++i) {
+    //Table << getBiny(channel,i).first << " - " << getBiny(channel,i).second << ",";
+    Table << TMath::Abs(systematics.at(i))*100 << ",";
+  }
+
+  Table.close();
+}
+
+//return the edges of a y bin
+std::pair<float,float> getBiny(int channel, int bin_number) 
+{
+  double *bins_vector_y = nullptr;
+  switch(channel) {
+  case 1: bins_vector_y = &ntkp_y_bins[0];     break;
+  case 2: bins_vector_y = &ntkstar_y_bins[0];  break;
+  case 4: bins_vector_y = &ntphi_y_bins[0];    break;
+  default: std::cout << "The chosen channel is not supported." << std::endl;
+  }
+  std::pair<float,float> pair = std::make_pair(bins_vector_y[bin_number],bins_vector_y[bin_number+1]);
+  return pair;
+}
+
+double getWeight(TFile *f, double muon_y, double muon_pt)
+{
+  TGraphAsymmErrors* h = nullptr;
+  if(TMath::Abs(muon_y)>=0. && TMath::Abs(muon_y)<0.2) h = static_cast<TGraphAsymmErrors*>(f->Get("ratio_0to0p2"));
+  else if(TMath::Abs(muon_y)>=0.2 && TMath::Abs(muon_y)<0.3) h = static_cast<TGraphAsymmErrors*>(f->Get("ratio_0p2to0p3"));
+  else if(TMath::Abs(muon_y)>=0.3 && TMath::Abs(muon_y)<0.9) h = static_cast<TGraphAsymmErrors*>(f->Get("ratio_0p3to0p9"));
+  else if(TMath::Abs(muon_y)>=0.9 && TMath::Abs(muon_y)<1.2) h = static_cast<TGraphAsymmErrors*>(f->Get("ratio_0p9to1p2"));
+  else if(TMath::Abs(muon_y)>=1.2 && TMath::Abs(muon_y)<1.6) h = static_cast<TGraphAsymmErrors*>(f->Get("ratio_1p2to1p6"));
+  else if(TMath::Abs(muon_y)>=1.6 && TMath::Abs(muon_y)<2.1) h = static_cast<TGraphAsymmErrors*>(f->Get("ratio_1p6to2p1"));  
+  else if(TMath::Abs(muon_y)>=2.1 && TMath::Abs(muon_y)<2.4) h = static_cast<TGraphAsymmErrors*>(f->Get("ratio_2p1to2p4"));
+  else std::cout << "The muon had a pseudo-rapidity of " << muon_y << "!" << std::endl;
+
+  if (muon_pt>=2. && muon_pt<=40.) return h->Eval(muon_pt); //values considered inside the weight maps
+  else {/*std::cout << "The muon has a pT of " << muon_pt << "!" << std::endl;*/ return 1.;}  
+}
+
+std::pair<int,int> currentBin(int nbins_y, int nbins_pt, double b_y, double b_pt, int channel) 
+{
+  double *bins_vector_pt = nullptr;
+  double *bins_vector_y = nullptr;
+  switch(channel) {
+  case 1: bins_vector_pt = &ntkp_pt_bins[0];     bins_vector_y = &ntkp_y_bins[0];    break;
+  case 2: bins_vector_pt = &ntkstar_pt_bins[0];  bins_vector_y = &ntkstar_y_bins[0]; break;
+  case 4: bins_vector_pt = &ntphi_pt_bins[0];    bins_vector_y = &ntphi_y_bins[0];   break;
+  default: std::cout << "The chosen channel is not supported." << std::endl;
+  }
+
+  b_y = TMath::Abs(b_y);
+  int pt_currBin = 0, y_currBin = 0;
+  for(int i=0; i<nbins_pt; ++i) 
+    {
+      if(b_pt >= bins_vector_pt[i] && b_pt < bins_vector_pt[i+1]) pt_currBin = i;
+    }
+  for(int i=0; i<nbins_y; ++i) 
+    {
+      if(b_y >= bins_vector_y[i] && b_y < bins_vector_y[i+1]) y_currBin = i;
+    }
+
+  std::pair<int,int> pair = std::make_pair(y_currBin,pt_currBin);
+  return pair;
+}

--- a/bin/YieldStability.cc
+++ b/bin/YieldStability.cc
@@ -1,0 +1,233 @@
+#include <stdio.h>
+#include <iostream>
+#include "TGraphErrors.h"
+#include "TCanvas.h"
+#include "TText.h"
+#include "TAxis.h"
+#include "TLatex.h"
+#include "TMath.h"
+
+int main() {
+
+  std::vector<std::string> labels = {"D1","D2","D3","D4","D5"};
+  unsigned int n = labels.size();
+  TCanvas *c1 = new TCanvas("c1","c1",10,10,1600,850);
+  c1->Divide(2,2);
+  
+  //////B+////////////////////////////////////////////
+  c1->cd(1); 
+
+  std::vector<double> x1  = {1.,2.,3.,4.,5.};
+  std::vector<double> N1 = {28373.000,37883.000,31043.000,15517.000,25832.000};
+  std::vector<double> eN1 = {233.000,283.000,264.000,183.000,254.000};
+  //std::vector<double> L1 = {0.200,0.542,0.935,0.321,0.585};
+  std::vector<double> L1 = {0.325,0.727,0.625,0.332,0.574};
+  std::vector<double> y1;
+  for (unsigned int i=0; i<n; ++i) {
+    y1.push_back(N1.at(i)/L1.at(i));
+  }
+  std::vector<double> ex1 = {0.,0.,0.,0.,0.};
+  std::vector<double> ey1;
+  for (unsigned int i=0; i<n; ++i) {
+    ey1.push_back(y1.at(i) * TMath::Sqrt(TMath::Power(eN1.at(i)/N1.at(i),2) + TMath::Power(0.023,2)));
+    std::cout << ey1.at(i) << std::endl;
+  }
+  
+  TGraphErrors *gr1 = new TGraphErrors(n,&x1[0],&y1[0],&ex1[0],&ey1[0]);
+  gr1->SetTitle("B^{+}");
+  gr1->SetMarkerColor(30);
+  gr1->SetMarkerStyle(21);
+  gr1->GetXaxis()->SetLabelSize(0.);
+  gr1->SetMinimum(20000);
+  gr1->Draw("ALP");
+
+  TLatex ytitle1;
+  ytitle1.SetTextSize(0.05);
+  ytitle1.DrawLatex(-0.05,85000.,"N/L");
+
+  TText *t = new TText();
+  t->SetTextAlign(32);
+  t->SetTextSize(0.035);
+  t->SetTextFont(72);
+  for (unsigned int i=0; i<labels.size(); i++) {
+    t->DrawText(x1.at(i), 30000, labels.at(i).c_str());
+  }
+  
+
+  //////B0////////////////////////////////////////////
+  c1->cd(2); 
+
+  std::vector<double> x2  = {1.,2.,3.,4.,5.};
+  std::vector<double> N2 = {11895.000,15482.000,12564.000,6051.000,9953.000};
+  std::vector<double> eN2 = {142.000,163.000,150.000,105.000,132.000};
+  //std::vector<double> L2 = {0.200,0.542,0.935,0.321,0.585};
+  std::vector<double> L2 = {0.325,0.727,0.625,0.332,0.574};
+  std::vector<double> y2;
+  for (unsigned int i=0; i<n; ++i) {
+    y2.push_back(N2.at(i)/L2.at(i));
+  }
+  std::vector<double> ex2 = {0.,0.,0.,0.,0.};
+  std::vector<double> ey2;
+  for (unsigned int i=0; i<n; ++i) {
+    ey2.push_back(y2.at(i) * TMath::Sqrt(TMath::Power(eN2.at(i)/N2.at(i),2) + TMath::Power(0.023,2)));
+    std::cout << ey2.at(i) << std::endl;
+  }
+  
+  TGraphErrors *gr2 = new TGraphErrors(n,&x2[0],&y2[0],&ex2[0],&ey2[0]);
+  gr2->SetTitle("B_{0}");
+  gr2->SetMarkerColor(30);
+  gr2->SetMarkerStyle(21);
+  gr2->GetXaxis()->SetLabelSize(0.);
+  gr2->SetMinimum(10000);
+  gr2->Draw("ALP");
+
+  TLatex ytitle2;
+  ytitle2.SetTextSize(0.05);
+  ytitle2.DrawLatex(-0.05,37000.,"N/L");
+
+  for (unsigned int i=0; i<labels.size(); i++) {
+    t->DrawText(x2.at(i), 13000, labels.at(i).c_str());
+  }
+
+  //////Bs////////////////////////////////////////////
+  c1->cd(4); 
+
+  std::vector<double> x4  = {1.,2.,3.,4.,5.};
+  std::vector<double> N4 = {2103.000,2743.000,2065.000,1067.000,1741.000};
+  std::vector<double> eN4 = {56.000,65.000,57.000,41.000,50.000};
+  //std::vector<double> L4 = {0.200,0.542,0.935,0.321,0.585};
+  std::vector<double> L4 = {0.325,0.727,0.625,0.332,0.574};
+  std::vector<double> y4;
+  for (unsigned int i=0; i<n; ++i) {
+    y4.push_back(N4.at(i)/L4.at(i));
+  }
+  std::vector<double> ex4 = {0.,0.,0.,0.,0.};
+  std::vector<double> ey4;
+  for (unsigned int i=0; i<n; ++i) {
+    ey4.push_back(y4.at(i) * TMath::Sqrt(TMath::Power(eN4.at(i)/N4.at(i),2) + TMath::Power(0.023,2)));
+    std::cout << ey4.at(i) << std::endl;
+  }
+  
+  TGraphErrors *gr4 = new TGraphErrors(n,&x4[0],&y4[0],&ex4[0],&ey4[0]);
+  gr4->SetTitle("B_{s}");
+  gr4->SetMarkerColor(30);
+  gr4->SetMarkerStyle(21);
+  gr4->GetXaxis()->SetLabelSize(0.);
+  gr4->SetMinimum(1400);
+  gr4->Draw("ALP");
+
+  TLatex ytitle4;
+  ytitle4.SetTextSize(0.045);
+  ytitle4.DrawLatex(-0.05,6500.,"N/L");
+
+  for (unsigned int i=0; i<labels.size(); i++) {
+    t->DrawText(x4.at(i), 2100, labels.at(i).c_str());
+  }
+
+  c1->Update();
+  c1->SaveAs("YieldStability.png");
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+  /////////////////////////////////////////////////////////////////////////////////////////////////////
+  /////////////////////////////////////////////////////////////////////////////////////////////////////
+  TCanvas *c2 = new TCanvas("c2","c2",10,10,1050,850);
+  c2->Divide(2,2); 
+
+  /////////// B0/B+ //////////////////////////////////////////////
+  c2->cd(1);
+  std::vector<double> ratio1;
+  for(unsigned int i=0; i<n; ++i) {
+    ratio1.push_back(N2.at(i)/N1.at(i));
+  }
+  std::vector<double> eratio1;
+  for (unsigned int i=0; i<n; ++i) {
+    eratio1.push_back(ratio1.at(i) * TMath::Sqrt(TMath::Power(eN1.at(i)/N1.at(i),2) + TMath::Power(eN2.at(i)/N2.at(i),2)));
+  }
+  TGraphErrors *gr_ratio1 = new TGraphErrors(n,&x1[0],&ratio1[0],&ex1[0],&eratio1[0]);
+  gr_ratio1->SetTitle("B^{0}/B^{+}");
+  gr_ratio1->SetMarkerColor(38);
+  gr_ratio1->SetMarkerStyle(21);
+  gr_ratio1->GetXaxis()->SetLabelSize(0.);
+  gr_ratio1->SetMinimum(0.495);
+  gr_ratio1->Draw("ALP");
+
+  TLatex ytitle_ratio1;
+  ytitle_ratio1.SetTextSize(0.045);
+  ytitle_ratio1.DrawLatex(-0.8,0.539,"#frac{N_{B^{0}}}{N_{B^{+}}}");
+  
+  for (unsigned int i=0; i<labels.size(); i++) {
+    t->DrawText(x1.at(i), 0.505, labels.at(i).c_str());
+  }
+
+  /////////// B0/Bs //////////////////////////////////////////////
+  c2->cd(2);
+  std::vector<double> ratio2;
+  for(unsigned int i=0; i<n; ++i) {
+    ratio2.push_back(N2.at(i)/N4.at(i));
+  }
+  std::vector<double> eratio2;
+  for (unsigned int i=0; i<n; ++i) {
+    eratio2.push_back(ratio2.at(i) * TMath::Sqrt(TMath::Power(eN4.at(i)/N4.at(i),2) + TMath::Power(eN2.at(i)/N2.at(i),2)));
+  }
+  TGraphErrors *gr_ratio2 = new TGraphErrors(n,&x2[0],&ratio2[0],&ex2[0],&eratio2[0]);
+  gr_ratio2->SetTitle("B^{0}/B_{s}");
+  gr_ratio2->SetMarkerColor(38);
+  gr_ratio2->SetMarkerStyle(21);
+  gr_ratio2->GetXaxis()->SetLabelSize(0.);
+  gr_ratio2->SetMinimum(5.40);
+  gr_ratio2->Draw("ALP");
+
+  TLatex ytitle_ratio2;
+  ytitle_ratio2.SetTextSize(0.045);
+  ytitle_ratio2.DrawLatex(-0.8,7.35,"#frac{N_{B^{0}}}{N_{B_{s}}}");
+  
+  for (unsigned int i=0; i<labels.size(); i++) {
+    t->DrawText(x2.at(i), 6.75, labels.at(i).c_str());
+  }
+
+
+  /////////// Bs/B+ //////////////////////////////////////////////
+  c2->cd(4);
+  std::vector<double> ratio4;
+  for(unsigned int i=0; i<n; ++i) {
+    ratio4.push_back(N4.at(i)/N1.at(i));
+  }
+  std::vector<double> eratio4;
+  for (unsigned int i=0; i<n; ++i) {
+    eratio4.push_back(ratio1.at(i) * TMath::Sqrt(TMath::Power(eN1.at(i)/N1.at(i),2) + TMath::Power(eN4.at(i)/N4.at(i),2)));
+  }
+  TGraphErrors *gr_ratio4 = new TGraphErrors(n,&x4[0],&ratio4[0],&ex4[0],&eratio4[0]);
+  gr_ratio4->SetTitle("B_{s}/B^{+}");
+  gr_ratio4->SetMarkerColor(38);
+  gr_ratio4->SetMarkerStyle(21);
+  gr_ratio4->GetXaxis()->SetLabelSize(0.);
+  gr_ratio4->SetMaximum(0.09);
+  gr_ratio4->SetMinimum(0.055);
+  gr_ratio4->Draw("ALP");
+
+  TLatex ytitle_ratio4;
+  ytitle_ratio4.SetTextSize(0.05);
+  ytitle_ratio4.DrawLatex(-0.85,0.0885,"#frac{N_{B_{s}}}{N_{B^{+}}}");
+  
+  for (unsigned int i=0; i<labels.size(); i++) {
+    t->DrawText(x4.at(i), 0.06, labels.at(i).c_str());
+  }
+
+  c2->Update();
+  c2->SaveAs("YieldStability_ratios.png");
+
+  double maxdev1 = ( ratio1.at(4) - (ratio1.at(0)+ratio1.at(1)+ratio1.at(2)+ratio1.at(3)+ratio1.at(4))/5 ) / ( (ratio1.at(0)+ratio1.at(1)+ratio1.at(2)+ratio1.at(3)+ratio1.at(4))/5 );
+  double maxdev1_bruno = ( ratio1.at(4) - (ratio1.at(0)+ratio1.at(1)+ratio1.at(2)+ratio1.at(3)+ratio1.at(4))/5 ) / (2*(eratio1.at(0)+eratio1.at(1)+eratio1.at(2)+eratio1.at(3)+eratio1.at(4))/5 );
+
+  double maxdev2 = ( ratio2.at(1) - (ratio2.at(0)+ratio2.at(1)+ratio2.at(2)+ratio2.at(3)+ratio2.at(4))/5 ) / ( (ratio2.at(0)+ratio2.at(1)+ratio2.at(2)+ratio2.at(3)+ratio2.at(4))/5 );
+  double maxdev2_bruno = ( ratio2.at(1) - (ratio2.at(0)+ratio2.at(1)+ratio2.at(2)+ratio2.at(3)+ratio2.at(4))/5 ) / (2*(eratio2.at(0)+eratio2.at(1)+eratio2.at(2)+eratio2.at(3)+eratio2.at(4))/5 );
+
+  double maxdev4 = ( ratio4.at(1) - (ratio4.at(0)+ratio4.at(1)+ratio4.at(2)+ratio4.at(3)+ratio4.at(4))/5 ) / ( (ratio4.at(0)+ratio4.at(1)+ratio4.at(2)+ratio4.at(3)+ratio4.at(4))/5 );
+  double maxdev4_bruno = ( ratio4.at(1) - (ratio4.at(0)+ratio4.at(1)+ratio4.at(2)+ratio4.at(3)+ratio4.at(4))/5 ) / (2*(eratio4.at(0)+eratio4.at(1)+eratio4.at(2)+eratio4.at(3)+eratio4.at(4))/5 );
+
+  std::cout << maxdev1 << "; " << maxdev1_bruno << std::endl;
+  std::cout << maxdev2 << "; " << maxdev2_bruno << std::endl;
+  std::cout << maxdev4 << "; " << maxdev4_bruno << std::endl;
+
+ return 0;
+}

--- a/bin/calculate_bin_fitbias.cc
+++ b/bin/calculate_bin_fitbias.cc
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include "UserCode/B_production_x_sec_13_TeV/interface/functions.h"
 #include "TRandom.h"
 
@@ -68,7 +67,7 @@ int main(int argc, char** argv)
 
   RooMCStudy* mcstudy = new RooMCStudy(*model_open,mass_open,Binned(kTRUE),Silence(),Extended(),FitOptions(Save(kTRUE),PrintEvalErrors(0)));
 
-  mcstudy->generateAndFit(10/*,gRandom->Poisson(data_open->numEntries())*/);
+  mcstudy->generateAndFit(5000/*,gRandom->Poisson(data_open->numEntries())*/);
 
   std::cout << data_open->numEntries() << std::endl;
 

--- a/bin/mc_validation.cc
+++ b/bin/mc_validation.cc
@@ -650,10 +650,6 @@ std::vector<TH1D*> sideband_sub(RooWorkspace& w, RooWorkspace& w_mc, int channel
   //reduceddata_side->plotOn(massframe,Range("all"));
   data->plotOn(massframe,Range("all"));
   fit_side.plotOn(massframe/*, Range("all")*/);
-  massframe->GetYaxis()->SetTitleOffset(1.2);
-  /*Bp:  massframe->GetYaxis()->SetRangeUser(800,58000);*/
-  /*B0: massframe->GetYaxis()->SetRangeUser(800,26000);*/
-  /*Bs: */massframe->GetYaxis()->SetRangeUser(90,8000);
   TString B = "";
   switch(channel) {
   case 1: B = "B^{+}"; break;
@@ -680,6 +676,10 @@ std::vector<TH1D*> sideband_sub(RooWorkspace& w, RooWorkspace& w_mc, int channel
 
   TCanvas d, d_linear;
   d.cd();  
+  massframe->GetYaxis()->SetTitleOffset(1.1);
+  /*Bp: */massframe->GetYaxis()->SetRangeUser(800,58000);
+  /*B0: massframe->GetYaxis()->SetRangeUser(800,42000);*/
+  /*Bs: massframe->GetYaxis()->SetRangeUser(90,8000);*/
   massframe->Draw();
   TLatex* tex12 = new TLatex(0.65, 0.50, Form("#lambda = %.3lf #pm %.3lf",lambda_str,lambda_err));
   tex12->SetNDC(kTRUE);
@@ -690,6 +690,10 @@ std::vector<TH1D*> sideband_sub(RooWorkspace& w, RooWorkspace& w_mc, int channel
   std::string canvas = channel_to_ntuple_name(channel) + "_background_fit.png";
   d.SaveAs(canvas.c_str());
   d_linear.cd();
+  massframe->GetYaxis()->SetTitleOffset(1.35);
+  /*Bp: */massframe->GetYaxis()->SetRangeUser(1,58000);
+  /*B0: massframe->GetYaxis()->SetRangeUser(1,42000);*/
+  /*Bs: massframe->GetYaxis()->SetRangeUser(1,8000); */
   massframe->Draw();
   tex12->Draw();
   d_linear.SaveAs(("linear_"+canvas).c_str());   


### PR DESCRIPTION
The two macros here added were used to perform the 'Yield Stability' check.
The RunNoFilter.cc macro splits a dataset into several ones according to the 'run number' variable, and creates separated '.json' files according to the splitting.
The Yield Stability.cc macro receives as inputs the luminosity and the yield of each of the splitted datasets, per channel, and plots the results, both for Yield / Luminosity and for Yield (channel X) / Yield (channel Z), the second being a cross-check.